### PR TITLE
Add swift type for optional functions

### DIFF
--- a/Sources/UserDefaultsGeneratorCore/Generator.swift
+++ b/Sources/UserDefaultsGeneratorCore/Generator.swift
@@ -37,6 +37,7 @@ private func buildArguments(_ configurations: [Configuration]) -> [String: Any] 
                 return [
                     "key": swiftType,
                     "typeName": swiftType.typeName,
+                    "isOptionalType": swiftType.isOptional,
                     "getterMethodName": swiftType.getterMethodName,
                     "configurations": configurations
                         .map { configuration -> [String: Any] in

--- a/Sources/UserDefaultsGeneratorCore/Generator.swift
+++ b/Sources/UserDefaultsGeneratorCore/Generator.swift
@@ -33,11 +33,11 @@ private func buildArguments(_ configurations: [Configuration]) -> [String: Any] 
     let groupedConfigurations = configurations.grouped { $0.type }.ordered()
     return [
         "groupedConfigurations": groupedConfigurations
-            .map { (key, configurations) -> [String: Any] in
+            .map { (swiftType, configurations) -> [String: Any] in
                 return [
-                    "key": key,
-                    "typeName": key.typeName,
-                    "getterMethodName": key.getterMethodName,
+                    "key": swiftType,
+                    "typeName": swiftType.typeName,
+                    "getterMethodName": swiftType.getterMethodName,
                     "configurations": configurations
                         .map { configuration -> [String: Any] in
                             return [

--- a/Sources/UserDefaultsGeneratorCore/SwiftType.swift
+++ b/Sources/UserDefaultsGeneratorCore/SwiftType.swift
@@ -23,6 +23,15 @@ public enum SwiftType: String, Decodable {
     var typeName: String {
         return rawValue
     }
+    
+    var isOptional: Bool {
+        switch self {
+        case .any, .url, .array, .dictionary, .string, .stringArray, .data:
+            return true
+        case .bool, .int, .float, .double:
+            return false
+        }
+    }
 
     var getterMethodName: String {
         switch self {

--- a/Sources/UserDefaultsGeneratorCore/Template.swift
+++ b/Sources/UserDefaultsGeneratorCore/Template.swift
@@ -29,10 +29,10 @@ enum TemplateType {
             {% set gc groupedConfiguration %}
             // MARK: - UserDefaults {{ gc.typeName }} Extension
             extension UserDefaults {
-            \(tab)public func {{ gc.getterMethodName }}(forKey key: UDG{{ gc.typeName }}Key) -> {{ gc.typeName }} {
+            \(tab)public func {{ gc.getterMethodName }}(forKey key: UDG{{ gc.typeName }}Key) -> {{ gc.typeName }}{% if gc.isOptionalType %}?{% endif %} {
             \(tab)\(tab)return {{ gc.getterMethodName }}(forKey: key.rawValue)
             \(tab)}
-            \(tab)public func set(_ value: {{ gc.typeName }}, forKey key: UDG{{ gc.typeName }}Key) {
+            \(tab)public func set(_ value: {{ gc.typeName }}{% if gc.isOptionalType %}?{% endif %}, forKey key: UDG{{ gc.typeName }}Key) {
             \(tab)\(tab)set(value, forKey: key.rawValue)
             \(tab)\(tab)synchronize()
             \(tab)}

--- a/Tests/UserDefaultsGeneratorCoreTests/GeneratorTests.swift
+++ b/Tests/UserDefaultsGeneratorCoreTests/GeneratorTests.swift
@@ -64,7 +64,7 @@ public enum UDGIntKey: String {
             """
             XCTAssertEqual(got, expected)
         }
-        XCTContext.runActivity(named: "When swift type is Bool") { (_) in
+        XCTContext.runActivity(named: "When swift type is Bool. And add custom enum key name") { (_) in
             let configurations: [Configuration] = [
                 Configuration(name: "enumKey", type: .bool, key: "Custom"),
             ]
@@ -82,6 +82,27 @@ public enum UDGIntKey: String {
             \(tab)}
             }
 
+            """
+            XCTAssertEqual(got, expected)
+        }
+        XCTContext.runActivity(named: "When swift type is Any. Any is optional type") { (_) in
+            let configurations: [Configuration] = [
+                Configuration(name: "enumKey", type: .any, key: nil),
+            ]
+            let got = userDefaultsExtensions(configurations: configurations)
+            let expected = """
+            
+            // MARK: - UserDefaults Any Extension
+            extension UserDefaults {
+            \(tab)public func object(forKey key: UDGAnyKey) -> Any? {
+            \(tab)\(tab)return object(forKey: key.rawValue)
+            \(tab)}
+            \(tab)public func set(_ value: Any?, forKey key: UDGAnyKey) {
+            \(tab)\(tab)set(value, forKey: key.rawValue)
+            \(tab)\(tab)synchronize()
+            \(tab)}
+            }
+            
             """
             XCTAssertEqual(got, expected)
         }


### PR DESCRIPTION
## What
- Add property for `isOptional`
- Add template environment named by `isOptionalType`
- Edit template to use `isOptionalType`

## Why
Integrate function rules to the apple document.
https://developer.apple.com/documentation/foundation/userdefaults